### PR TITLE
Make e2e tests work, still failling the c10k which now starts with 1k.

### DIFF
--- a/test/e2e/c10k.ts
+++ b/test/e2e/c10k.ts
@@ -1,37 +1,71 @@
 import chai from "chai";
 import chaiHttp from "chai-http";
+import http from 'http';
 
 chai.should();
 const SERVER_URL = process.env.APP_URL || "http://localhost:8080";
+const SERVER_HOST = SERVER_URL ? null : "localhost";
 chai.use(chaiHttp);
 
 describe.skip("c10k", () => {
 
-  describe("10000 x GET /", () => {
-    it("should allow 10k requests without killing the server", done => {
-      const times: number = 10000;
-      const requests = [];
+  describe("1000 x GET /", () => {
+    it("should allow 1k requests without killing the server", done => {
+      const times = 1000;
+      const results: (number | undefined)[] = [];
+      let j = 0;
 
       for (let i = 0; i < times; i++) {
+        http.request({
+          host: SERVER_HOST,
+          port: 8080,
+          path: '/'
+        }, function (res) {
+          results.push(res.statusCode);
+          j++;
 
-        chai
-          .request(SERVER_URL)
-          .get("/")
-          .end((err, res) => {
-            if (err) done(err)
+          if (j == i) { // last request
+            const filterred = results.filter((result) => !!result);
 
-            // Check the response created by the server on the console
-            console.log({ res, i });
-
-            requests.push(i)
-
-            res.should.have.status(200);
-            res.should.be.html;
-            res.text.should.include('Welcome to our server');
-
-            if (requests.length === times) done();
-          });
+            if (filterred.length === times) {
+              done()
+            } else {
+              done('failed');
+            }
+          }
+        }).end();
       }
+
+    });
+  });
+
+  describe("10000 x GET /", () => {
+    it("should allow 10k requests without killing the server", done => {
+      const times = 10000;
+      const results: (number | undefined)[] = [];
+      let j = 0;
+
+      for (let i = 0; i < times; i++) {
+        http.request({
+          host: SERVER_HOST,
+          port: 8080,
+          path: '/'
+        }, function (res) {
+          results.push(res.statusCode);
+          j++;
+
+          if (j == i) { // last request
+            const filterred = results.filter((result) => !!result);
+
+            if (filterred.length === times) {
+              done()
+            } else {
+              done('failed');
+            }
+          }
+        }).end();
+      }
+
     });
   });
 

--- a/test/e2e/index.ts
+++ b/test/e2e/index.ts
@@ -7,21 +7,16 @@ chai.use(chaiHttp);
 
 /*
 
-Currently not working due to:
+For this to work:
 
-  1) General
-       GET /
-         should return index:
-     Error: Parse Error: Invalid response status
-      at Socket.socketOnData (_http_client.js:509:22)
-      at addChunk (internal/streams/readable.js:309:12)
-      at readableAddChunk (internal/streams/readable.js:284:9)
-      at Socket.Readable.push (internal/streams/readable.js:223:10)
-      at TCP.onStreamRead (internal/stream_base_commons.js:188:23)
+  -   have webserv running locally
+  -   go to browser and navigate to localhost:8080
+      if you skip this step server will shut down when running test suite
+  -   run `make test_e2e` from root, always keep checking if local running server shutdown
 
 */
 
-describe.skip("General", () => {
+describe("General", () => {
 
   describe("GET /", () => {
     it("should return index", done => {
@@ -33,9 +28,6 @@ describe.skip("General", () => {
         .end((err, res) => {
           if (err) done(err)
 
-          // Check the response created by the server on the console
-          console.log({res});
-
           res.should.have.status(200);
           res.should.be.html;
           res.text.should.include('Welcome to our server');
@@ -45,7 +37,7 @@ describe.skip("General", () => {
 
   });
 
-  describe.skip("GET /test/forest.jpeg", () => {
+  describe("GET /test/forest.jpeg", () => {
     it("should return requested image", done => {
       chai
         .request(SERVER_URL)
@@ -54,9 +46,12 @@ describe.skip("General", () => {
           if (err) done(err)
 
           // Check the response created by the server on the console
-          console.log({res});
+          // console.log({res});
 
           res.should.have.status(200);
+          res.body.should.exist;
+          res.should.have.header('content-type', 'image/jpeg');
+          res.should.have.header('content-length', '5739587');
           done();
         });
     });


### PR DESCRIPTION
This is now suddenly working again which is super cool:

<img width="391" alt="Screenshot 2022-08-25 at 14 56 17" src="https://user-images.githubusercontent.com/36212418/186670526-314b3b0e-9419-405c-a5ad-3033532b60ac.png">

To make it work:

  -   have `./webserv` running locally
  -   go to browser and navigate to `localhost:8080`
      **NOTE** if you skip this step server will shut down when running test suite
  -   run `make test_e2e` from root, always keep checking if local running server shutdown

```
make test_e2e
```

To skip add `.skip` between `describe(` and the first parenthesis, to remove skip remove it.

Currently failing at the 1000x requests but already much more info to work with.

Currently testing successfully GET image, and regular GET.

Uncomment console log to see response returned.